### PR TITLE
add the good old pif

### DIFF
--- a/docs/pif.rst
+++ b/docs/pif.rst
@@ -8,6 +8,7 @@ However, summarizing values removes some of the details, e.g.: an average remove
 
 Feature Information Gain
 --------------------------
+
 FIG is given by summing all CIG values for each feature. The FIG can be
 used to identify the features that provides the highest information gain. Higher information gain
 corresponds to higher risk of of re-identification.
@@ -21,6 +22,18 @@ Row Information Gain
 RIG is determined by summing all the CIG values in the row and is a
 measure of the information gain associated with a particular individual if
 their information is revealed through re-identification.
+
+
+:math:`\text{PIF}_n`
+--------------------
+
+The initial definition of the PIF was a summary of the individual row information gain values. The :math:`\text{PIF}_n`
+is defined as the n\ :superscript:`th` percentile of the individual RIG values of a dataset.
+E.g.: 95% of the RIG values of a dataset won't exceed the :math:`\text{PIF}_{95}` value. Note that the RIG measures the
+overall information gain for an individual.
+
+Keep in mind that a :math:`\text{PIF}_n` value only summarises the risk of :math:`n\%` of the individuals in the dataset.
+
 
 Caution
 --------

--- a/piflib/pif_calculator.py
+++ b/piflib/pif_calculator.py
@@ -122,6 +122,29 @@ def compute_csfs(df, feature_priors={}, feature_accuracies={}):
     return pd.DataFrame(list(zip(*feature_csfs)), columns=df.columns)
 
 
+def compute_pif(cigs, percentile):
+    """ compute the PIF.
+
+    The PIF is defined as the n-th percentile of the individual RIG values. Or in other words, the RIG of n percent of
+    the entities in the dataset does not exceed the PIF value.
+
+    RIG stands for row information gain. It represents the overall information gain for an entity in the dataset. The
+    RIG is computed by summing the CIG values of an entity.
+
+    The percentile value can be chosen between 0 and 100. 100 will return the maximum RIG value. Often, the RIG values
+    from a long tail distribution with few high value outliers. Choosing a percentile value lower than 100 will ignore
+    (some of) the highest values. If ignoring the risk of some entities in the dataset fits within your risk framework,
+    then specifying a percentile value of less than 100 will make the PIF value less susceptible to RIG outliers.
+
+    :param cigs: The CIG values of the dataset (see the compute_cigs function in this module)
+    :param percentile: Which percentile of RIG values should be included in the PIF.
+    :returns: the PIF_percentile value of the given CIGs
+    """
+    rigs = cigs.sum(axis=1)
+    pif = np.percentile(rigs, percentile)
+    return pif
+
+
 def compute_posterior_distributions(feature, df):
     known_features = tuple(col_name for col_name in df.columns if col_name != feature)
     bucket = collections.defaultdict(list)

--- a/tests/test_pif_calculator.py
+++ b/tests/test_pif_calculator.py
@@ -16,6 +16,11 @@ data = {'A': [1, 1, 2, 2],
         'C': ['blue', 'green', 'red', 'cyan']}
 df_fully_dependent = pd.DataFrame(data)
 
+data = {'A': [1, 1, 2, 2],
+        'B': ['a', 'b', 'b', 'b'],
+        'C': ['blue', 'green', 'red', 'cyan']}
+df_mix = pd.DataFrame(data)
+
 
 def test_compute_cigs():
     # if every value in a column is the same, then there is no information gain
@@ -31,6 +36,7 @@ def test_compute_cigs():
     assert (cigs.A == 1).all()
     assert (cigs.B == 1).all()
     assert (cigs.C == 1).all()
+    pif_95 = pif.compute_pif(cigs, 0.95)
 
 
 def test_compute_weighted_cigs():
@@ -60,3 +66,15 @@ def test_compute_csfs():
     assert (csfs.A == 0.5).all()
     assert (csfs.B == 0.5).all()
     assert (csfs.C == 0.25).all()
+
+
+def test_compute_pif():
+    cigs = pif.compute_cigs(df_mix)
+    pif_100 = pif.compute_pif(cigs, 100)
+    rigs = cigs.sum(axis=1)
+    assert pif_100 == rigs.max()
+    pif_0 = pif.compute_pif(cigs, 0)
+    assert pif_0 == rigs.min()
+    assert pif.compute_pif(cigs, 99) < pif_100
+    pif_50 = pif.compute_pif(cigs, 50)
+    assert rigs[2] < pif_50 < rigs[1]


### PR DESCRIPTION
The ACS whitepaper had a definition of PIF_n as the n_th percentile of the dataset's RIG values.
This PR adds this measure to the code base.